### PR TITLE
Update MPR link in header.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,5 @@ enableEmoji = true
 
 [params]
 	site_desc = "A simplicity-focused packaging tool for Debian archives"
-	hw_url = "hunterwittenborn.com"
 	makedeb_url = "makedeb.org"
 	github_url = "github.com"

--- a/themes/makedeb/layouts/partials/header.html
+++ b/themes/makedeb/layouts/partials/header.html
@@ -16,7 +16,7 @@
 		{{ end }}
 
 		<a href="https://docs.{{ .Site.Params.makedeb_url }}">Docs</a>
-		<a href="https://mpr.{{ .Site.Params.hw_url }}">MPR</a>
+		<a href="https://mpr.{{ .Site.Params.makedeb_url }}">MPR</a>
 
 		{{ if eq .RelPermalink "/news/" }}
 		<p>News</p>


### PR DESCRIPTION
Was previously mpr.hunterwittenborn.com which no longer works.